### PR TITLE
version 2.0.0+2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,18 @@
 <details>
   <summary>Table of Contents</summary>
   <ol>
-    <li><a href="#binaries-for-features">Binaries for Features</a></li>
-    <li><a href="#binaries-for-tests">Binaries for Tests</a></li>
+    <li><a href="#scripts-for-development">Scripts for Development</a></li>
     <li><a href="#user-for-tests">User for Tests</a></li>
   </ol>
 </details>
 
 <br>
 
-## Binaries for Features
+## Scripts for Development
 
 <br>
 
-In the folder 'bin' we have some binaries to generate or update feature assets, they are:
-- <b>catalog_csv_convert.ps1:</b> used to convert catmat.csv and catser.csv files, into *.json (used for debug purposes) and *.min.json (used by application). The csv files must be inside '/assets/catalog' folder. The output files will be generated in same folder.
-
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-## Binaries for Tests
-
-<br>
-
-In the folder 'bin' we also have some binaries to help development, they are:
+In the folder 'bin' we also have some scripts to help development, they are:
 - <b>coverage.ps1:</b> used to automate full coverage tests (using full_coverage package).
 - <b>start_firebase_emulators.ps1:</b> used to start firebase emulators with dummy data for tests.
 

--- a/bin/catalog_csv_convert.ps1
+++ b/bin/catalog_csv_convert.ps1
@@ -1,4 +1,0 @@
-.\bin\catalog_csv_converter.exe catser -i .\assets\catalog\catser.csv -o .\assets\catalog\catser.json
-.\bin\catalog_csv_converter.exe catser -i .\assets\catalog\catser.csv -o .\assets\catalog\catser.min.json -m
-.\bin\catalog_csv_converter.exe catmat -i .\assets\catalog\catmat.csv -o .\assets\catalog\catmat.json
-.\bin\catalog_csv_converter.exe catmat -i .\assets\catalog\catmat.csv -o .\assets\catalog\catmat.min.json -m

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cpedidos_pmp
 description: Controle de Pedidos da Prefeitura Municipal de Penápolis.
 publish_to: 'none'
-version: 2.0.0+1
+version: 2.0.0+2
 
 environment:
   sdk: '>=2.19.0 <3.0.0'


### PR DESCRIPTION
updated docs and removed catalog converter scripts and binaries.

the converter is now in a separated [repository](https://github.com/ph-developer/cpedidos-catmat-catser-converter).